### PR TITLE
Fix cso image display on production

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -70,7 +70,7 @@ return [
     */
 
     'links' => [
-        public_path('storage') => storage_path('app/public'),
+        public_path('storage') => storage_path('app'),
     ],
 
 ];

--- a/resources/views/components/header.blade.php
+++ b/resources/views/components/header.blade.php
@@ -30,7 +30,7 @@
                     <li><a href="{{ route('about-us') }}">about us</a></li>
                     <li><a href="{{ route('services') }}">services</a></li>
                     <li><a href="{{ route('publications') }}">publications</a></li>
-                    <li><a href="{{ route('cso-library') }}">library</a></li>
+                    <li><a href="{{ route('cso-library') }}">CSO Library</a></li>
                     <li><a href="{{ route('impact-stories') }}">impact stories</a></li>
                     <li><a href="{{ route('newsroom') }}">newsroom</a></li>
                     <li><a href="{{ route('events') }}">events/Trainings</a></li>

--- a/resources/views/cso-library.blade.php
+++ b/resources/views/cso-library.blade.php
@@ -22,7 +22,7 @@
                     <div class="cso-library-grid">
                         @foreach ($csos as $cso)
                         <div class="cso-card">
-                            <img src="{{  config('app.url').$cso->image }}" alt="" />
+                            <img src="{{ asset($cso->image) }}" alt="" />
                             <h2>{{$cso->name}}</h2>
                             <p>{{$cso->domain}}</p>
                         </div>


### PR DESCRIPTION
Changed the `config/filesystem.php` storage path from `app/public` to `app`, and also changed the `cso` image src attribute to `{{ asset($cso->image) }}`.
These changes make the path saved to the database identical to the path being referenced on the frontend, regardless of the environment

closes #26 