### PR TITLE
Update cso registration forms and cso assessment score property

### DIFF
--- a/app/Http/Controllers/CsoController.php
+++ b/app/Http/Controllers/CsoController.php
@@ -55,7 +55,6 @@ class CsoController extends Controller
     {
         $fields = $request->validate([
             'name' => ['required', 'string'],
-            'assessment_score' => ['integer', 'required'],
             'partnership' => ['required', 'string'],
             'registration_date' => ['required', 'string'],
             'organization_type' => ['required', 'string'],
@@ -87,7 +86,6 @@ class CsoController extends Controller
 
         $cso = Cso::create([
             'name' => $fields['name'],
-            'assessment_score' => $fields['assessment_score'],
             'partnership' => $fields['partnership'],
             'registration_date' => $fields['registration_date'],
             'organization_type' => $fields['organization_type'],

--- a/app/Orchid/Layouts/Cso/CsoBasicInfo.php
+++ b/app/Orchid/Layouts/Cso/CsoBasicInfo.php
@@ -32,14 +32,20 @@ class CsoBasicInfo extends Rows
                 ->help('Give the name of the CSO')
                 ->required(),
 
-            Input::make('cso.assessment_score')
+            Select::make('cso.assessment_score')
                 ->title('Assessment score')
+                ->options([
+                    'Assessment Level 01' => 'Assessment Level 01',
+                    'Assessment Level 02' => 'Assessment Level 02',
+                    'Assessment Level 03' => 'Assessment Level 03',
+                    'Assessment Level 04' => 'Assessment Level 04',
+                    'Assessment Level 05' => 'Assessment Level 05',
+                ])
                 ->placeholder('CSO assessment score')
-                ->help('Give the assessment score of the CSO')
-                ->type('number'),
+                ->help('Give the assessment score of the CSO'),
 
             Input::make('cso.partnership')
-                ->title('Partnership')
+                ->title('Acronym')
                 ->placeholder('CSO partnership')
                 ->help('Give the partnership of the CSO'),
 
@@ -73,6 +79,7 @@ class CsoBasicInfo extends Rows
                     'Media' => 'Media',
                     'Village development Association' => 'Village development Association',
                     'CSO Network' => 'CSO Network',
+                    'CBO' => 'CBO',
                     'Faith Based organization' => 'Faith Based organization',
                 ])
                 ->title('Type of organization')
@@ -89,15 +96,15 @@ class CsoBasicInfo extends Rows
                 ->required(),
 
             Input::make('cso.region')
-                ->title('Region')
+                ->title('State/Region/Country')
                 ->required(),
 
             Input::make('cso.division')
-                ->title('Division')
+                ->title('Region/Province')
                 ->required(),
 
             Input::make('cso.sub_division')
-                ->title('Sub division')
+                ->title('Sub Division')
                 ->required(),
 
             Input::make('cso.village')

--- a/app/Orchid/Layouts/Cso/CsoContactInfo.php
+++ b/app/Orchid/Layouts/Cso/CsoContactInfo.php
@@ -54,13 +54,13 @@ class CsoContactInfo extends Rows
                 ->required(),
 
             Input::make('cso.address')
-                ->title('CSO address')
+                ->title('CSO Physical Address')
                 ->placeholder('')
                 ->required(),
 
             Input::make('cso.website')
                 ->title('CSO Website')
-                ->type('url')
+                ->type('string')
                 ->required(),
 
             Input::make('cso.email')

--- a/database/factories/CsoFactory.php
+++ b/database/factories/CsoFactory.php
@@ -19,7 +19,7 @@ class CsoFactory extends Factory
     {
         return [
             'name' => $this->faker->company(),
-            'assessment_score' => $this->faker->numberBetween(0, 100),
+            'assessment_score' => $this->faker->randomElement(['Assessment Level 01', 'Assessment Level 02', 'Assessment Level 03', 'Assessment Level 04', 'Assessment Level 05']),
             'status' => $this->faker->randomElement(['approved', 'pending', 'rejected']),
             'partnership' => $this->faker->sentence(),
             'image' => $this->faker->imageUrl(),

--- a/database/migrations/2023_06_20_092548_create_csos_table.php
+++ b/database/migrations/2023_06_20_092548_create_csos_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('csos', function (Blueprint $table) {
             $table->id();
             $table->string('name');
-            $table->integer('assessment_score')->nullable();
+            $table->string('assessment_score')->nullable();
             $table->enum('status', ['approved', 'pending', 'rejected'])->default('pending');
             $table->string('partnership')->nullable();
             $table->string('image')->nullable();

--- a/resources/views/register-cso.blade.php
+++ b/resources/views/register-cso.blade.php
@@ -23,17 +23,7 @@
                                 @enderror
                             </div>
                             <div class="field">
-                                <label for="">Assessment score </label>
-                                <input type="number" name="assessment_score" id="assessment-score"
-                                    placeholder="CSO sssessment score" value="{{ old('assessment_score') }}" required>
-                                @error('assessment_score')
-                                    <span class="error-msg">{{ $message }}</span>
-                                @enderror
-                            </div>
-                        </div>
-                        <div class="flex">
-                            <div class="field">
-                                <label for="">Partnership</label>
+                                <label for="">Acronym</label>
                                 <input type="text" name="partnership" id="partnership" placeholder="CSO partnership"
                                     value="{{ old('partnership') }}" required>
                                 @error('partnership')
@@ -70,6 +60,7 @@
                                     <option value="CIG">CIG</option>
                                     <option value="Cooperative">Cooperative</option>
                                     <option value="Media">Media</option>
+                                    <option value="CBO">CBO</option>
                                     <option value="Village development Association">Village development Association
                                     </option>
                                     <option value="CSO Network">CSO Network</option>
@@ -94,7 +85,7 @@
                         </div>
                         <div class="flex">
                             <div class="field">
-                                <label for="">Region</label>
+                                <label for="">State/Region/Country</label>
                                 <input type="text" name="region" id="region" placeholder="region"
                                     value="{{ old('region') }}" required>
                                 @error('region')
@@ -102,7 +93,7 @@
                                 @enderror
                             </div>
                             <div class="field">
-                                <label for="">Devision</label>
+                                <label for="">Region/Province</label>
                                 <input type="text" name="division" id="division" placeholder="division"
                                     value="{{ old('division') }}" required>
                                 @error('division')
@@ -112,7 +103,7 @@
                         </div>
                         <div class="flex">
                             <div class="field">
-                                <label for="">Sub devision</label>
+                                <label for="">Sub Division</label>
                                 <input type="text" name="sub_division" id="sub-division" placeholder="sub-division"
                                     value="{{ old('sub_division') }}" required>
                             </div>
@@ -127,7 +118,7 @@
                         </div>
                         <div class="flex">
                             <label for="image">
-                                <span>Choose image</span>
+                                <span>Upload Logo( jpeg or PNG)</span>
                                 <input type="file" name="image" id="" accept="image/*" />
                                 @error('image')
                                     <span class="error-msg">{{ $message }}</span>
@@ -187,7 +178,7 @@
                                 @enderror
                             </div>
                             <div class="field">
-                                <label for="">CSO address</label>
+                                <label for="">CSO physical address</label>
                                 <input type="text" name="address" id="cso-address" placeholder="cso-address"
                                     value="{{ old('address') }}" required>
                                 @error('address')
@@ -197,8 +188,8 @@
                         </div>
                         <div class="flex">
                             <div class="field">
-                                <label for="">CSO website</label>
-                                <input type="url" name="website" id="cso-website" placeholder="cso-website"
+                                <label for="">CSO Website</label>
+                                <input type="text" name="website" id="cso-website" placeholder="cso-website"
                                     value="{{ old('website') }}" required>
                                 @error('website')
                                     <span class="error-msg">{{ $message }}</span>


### PR DESCRIPTION
The following changes were made:
- `CBO` was added to the list of organizations in cso registration forms
- `Partnership` field label was changed to `Acronym`
- `Region` field label was changed to `State/Region/Country`
- `Division` field label was changed to `Region/Province`
- `Sub devision` field label was changed to `Sub Division`
- Change/correct `Choose image` was changed to `upload Logo( jped or PNG)`
- Change/correct `CSO address` was changed to `CSO physical address`
- `CSO website` can accept `www.xxxxxx.org` or `https/xxxx.org`
- `CSO assessment score` column type was change from `integer` to `string` and input type was changed to select

closes #102, closes #96, closes #97, closes #99, closes #100, closes #101