### PR TITLE
Events and Cso fixes and corrections

### DIFF
--- a/app/Http/Controllers/CsoController.php
+++ b/app/Http/Controllers/CsoController.php
@@ -8,13 +8,18 @@ use Illuminate\Http\Request;
 
 class CsoController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
-        $csos = Cso::where('status', 'verified')->paginate(20);
+        $domain = $request->query('domain');
+        $csosQuery = Cso::where('status', 'verified');
+        if ($domain) {
+            $csosQuery = $csosQuery->where('domain', $domain)->orWhere('second_domain', $domain)->orWhere('third_domain', $domain);
+        }
+        $csos = $csosQuery->paginate(20);
         $cso_domains = CsoActivityDomain::orderBy('name', 'asc')->get();
 
         foreach ($cso_domains as $item) {
-            $csoNumber = Cso::where('domain', $item->name)->count();
+            $csoNumber = Cso::where('status', 'verified')->where('domain', $item->name)->orWhere('second_domain', $item->name)->orWhere('third_domain', $item->name)->count();
             $item->csoNumber = $csoNumber;
         }
 

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\ContactInfo;
 use App\Models\Event;
 use App\Models\EventRegistration;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
 
 class EventController extends Controller
 {
@@ -33,6 +35,9 @@ class EventController extends Controller
             'email' => ['email', 'required'],
             'phone' => ['string', 'nullable'],
             'other_details' => ['string', 'nullable'],
+            'sex' => ['string', 'required'],
+            'country' => ['string', 'required'],
+            'organization' => ['string', 'required'],
         ]);
 
         $eventRegistration = EventRegistration::create([
@@ -41,7 +46,24 @@ class EventController extends Controller
             'email' => $fields['email'],
             'phone' => $fields['phone'] ?? null,
             'other_details' => $fields['other_details'] ?? null,
+            'sex' => $fields['sex'],
+            'country' => $fields['country'],
+            'organization' => $fields['organization'],
         ]);
+
+        $contactInfo = ContactInfo::first();
+
+        Mail::send(
+            'mail.event',
+            [
+                'name' => $fields['name'],
+            ],
+            function ($message) use ($contactInfo, $fields) {
+                $message->from($contactInfo->listed_email_address);
+                $message->to($fields['email'], $fields['name'])
+                    ->subject('New event registration');
+            }
+        );
 
         return redirect('/events')->with('success', 'you have successfuly submited your participation request');
     }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -19,6 +19,8 @@ class Event extends Model
         'url',
         'entrance',
         'date',
+        'end_date',
+        'details',
     ];
 
     public function user(): BelongsTo

--- a/app/Models/EventRegistration.php
+++ b/app/Models/EventRegistration.php
@@ -19,6 +19,8 @@ class EventRegistration extends Model
         'email',
         'phone',
         'other_details',
+        'sex',
+        'country',
     ];
 
     public function event(): BelongsTo

--- a/app/Orchid/Layouts/EventRegistration/EventRegistrationListLayout.php
+++ b/app/Orchid/Layouts/EventRegistration/EventRegistrationListLayout.php
@@ -29,7 +29,10 @@ class EventRegistrationListLayout extends Table
             TD::make('name', 'Name'),
             TD::make('email', 'Email address'),
             TD::make('phone', 'Phone number'),
-            TD::make('other_details', 'Other details'),
+            TD::make('sex', 'Sex'),
+            TD::make('organization', 'Organization'),
+            TD::make('country', 'Country'),
+            TD::make('other_details', 'Motivation'),
             TD::make('created_at', 'Created'),
         ];
     }

--- a/app/Orchid/Layouts/ExpertProfile/ExpertPersonalInfo.php
+++ b/app/Orchid/Layouts/ExpertProfile/ExpertPersonalInfo.php
@@ -49,7 +49,7 @@ class ExpertPersonalInfo extends Rows
                 ->help('Select the status of the expert'),
 
             TextArea::make('expert.details')
-                ->title('details')
+                ->title('Expert bio details')
                 ->placeholder('Enter Expert details')
                 ->rows(5)
                 ->required(),

--- a/app/Orchid/Screens/Event/EventEditScreen.php
+++ b/app/Orchid/Screens/Event/EventEditScreen.php
@@ -9,6 +9,7 @@ use Orchid\Screen\Fields\Cropper;
 use Orchid\Screen\Fields\DateTimer;
 use Orchid\Screen\Fields\Input;
 use Orchid\Screen\Fields\Select;
+use Orchid\Screen\Fields\TextArea;
 use Orchid\Screen\Screen;
 use Orchid\Support\Facades\Alert;
 use Orchid\Support\Facades\Layout;
@@ -110,8 +111,17 @@ class EventEditScreen extends Screen
                     ->required(),
 
                 DateTimer::make('event.date')
-                    ->title('Event date')
-                    ->rows(3)
+                    ->title('Event start date')
+                    ->enableTime()
+                    ->required(),
+
+                DateTimer::make('event.end_date')
+                    ->title('Event end date')
+                    ->enableTime()
+                    ->required(),
+
+                TextArea::make('event.details')
+                    ->title('Event details')
                     ->required(),
 
                 Cropper::make('event.image')

--- a/app/Orchid/Screens/EventRegistration/EventRegistrationListScreen.php
+++ b/app/Orchid/Screens/EventRegistration/EventRegistrationListScreen.php
@@ -67,7 +67,7 @@ class EventRegistrationListScreen extends Screen
     public function export()
     {
         $eventRegistrations = EventRegistration::all();
-        $columnNames = ['id', 'name', 'email', 'phone', 'other_details', 'created_at'];
+        $columnNames = ['id', 'name', 'email', 'phone', 'sex', 'organization', 'country', 'other_details', 'created_at'];
 
         return $this->dataExportService->exportData($eventRegistrations, $columnNames, 'all_registrations');
     }

--- a/database/migrations/2023_07_03_055526_create_events_table.php
+++ b/database/migrations/2023_07_03_055526_create_events_table.php
@@ -18,6 +18,8 @@ return new class extends Migration
             $table->string('image');
             $table->string('type');
             $table->string('date');
+            $table->string('end_date');
+            $table->longText('details');
             $table->string('url');
             $table->string('entrance');
             $table->timestamps();

--- a/database/migrations/2023_07_10_122631_create_event_registrations_table.php
+++ b/database/migrations/2023_07_10_122631_create_event_registrations_table.php
@@ -15,9 +15,12 @@ return new class extends Migration
             $table->id();
             $table->integer('event_id');
             $table->string('name');
+            $table->string('sex');
+            $table->string('country');
             $table->string('email');
+            $table->string('organization');
             $table->string('phone')->nullable();
-            $table->string('other_details')->nullable();
+            $table->longText('other_details')->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/cso-directory.blade.php
+++ b/resources/views/cso-directory.blade.php
@@ -13,7 +13,7 @@
                     <nav>
                         <ul>
                             @foreach ($cso_domains as $domain)
-                                <li><a href="/">{{ $domain->name }} ({{ $domain->csoNumber }})</a></li>
+                                <li><a href="/cso-directory?domain={{$domain->name}}">{{ $domain->name }} ({{ $domain->csoNumber }})</a></li>
                             @endforeach
                         </ul>
                     </nav>

--- a/resources/views/event-participate.blade.php
+++ b/resources/views/event-participate.blade.php
@@ -32,6 +32,27 @@
                         </div>
                         <div class="flex">
                             <div class="field">
+                                <label for="sex">Sex</label>
+                               <select name="sex" id="" required>
+                                <option value="male">Male</option>
+                                <option value="female">Female</option>
+                               </select>
+                                @error('sex')
+                                    <span class="error-msg">{{ $message }}</span>
+                                @enderror
+                            </div>
+                            <div class="field">
+                                <label for="country">Country of origin</label>
+                                <select name="country" id="" required>
+                                    <option value="cameroon" selected>Cameroon</option>
+                                </select>
+                                @error('country')
+                                    <span class="error-msg">{{ $message }}</span>
+                                @enderror
+                            </div>
+                        </div>
+                        <div class="flex">
+                            <div class="field">
                                 <label for="phone">Phone number</label>
                                 <input type="tel" name="phone" id="phone"
                                     placeholder="+237656000000" value="{{ old('phone') }}">
@@ -40,7 +61,17 @@
                                 @enderror
                             </div>
                             <div class="field">
-                                <label for="other_details">Other details</label>
+                                <label for="organization">Organization</label>
+                                <input type="text" name="organization" id="organization" placeholder=""
+                                    value="{{ old('organization') }}" required>
+                                @error('organization')
+                                    <span class="error-msg">{{ $message }}</span>
+                                @enderror
+                            </div>
+                        </div>
+                        <div class="flex">
+                        <div class="field">
+                                <label for="other_details">Your motivation to attend</label>
                                 <textarea name="other_details" id="other_details" value="{{ old('other_details') }}"></textarea>
                                 @error('other_details')
                                     <span class="error-msg">{{ $message }}</span>

--- a/resources/views/events.blade.php
+++ b/resources/views/events.blade.php
@@ -11,7 +11,7 @@
             <div class="con">
                 <div class="events-grid">
                     @foreach ($events as $event)
-                    <div class="event-card">
+                    <a href="{{ route('event-participate', ['event' => $event->id]) }}" class="event-card">
                         <div class="img-con">
                             <img src="{{ asset($event->image) }}" alt="" />
                             <div class="type event">{{$event->type}}</div>
@@ -22,9 +22,8 @@
                         </div>
                         <div class="content">
                             <p>{{$event->name}}</p>
-                            <a href="{{ route('event-participate', ['event' => $event->id]) }}" class="custom-button primary"><span>Participate</span></a>
                         </div>
-                    </div>
+                    </a>
                     @endforeach
                 </div>
                 <div class="pagination">

--- a/resources/views/lodge-details.blade.php
+++ b/resources/views/lodge-details.blade.php
@@ -90,14 +90,6 @@
                             <h3>Reserve</h3>
                         </div>
                         <form action="" class="book-form">
-                            <div class="field">
-                                <label for="">Arrival</label>
-                                <input type="date" name="" id="">
-                            </div>
-                            <div class="field">
-                                <label for="">Departure</label>
-                                <input type="date" name="" id="">
-                            </div>
                             <button type="button" class="custom-button primary" data-bs-toggle="modal"
                                 data-bs-target="#bookingModal">Book now</button>
                         </form>

--- a/resources/views/mail/event.blade.php
+++ b/resources/views/mail/event.blade.php
@@ -1,0 +1,3 @@
+<h2>Hello {{ $name }}, thank you for registering to our event</h2>
+<br>
+Thank you

--- a/resources/views/register-expert-profile.blade.php
+++ b/resources/views/register-expert-profile.blade.php
@@ -58,7 +58,7 @@
                             </div>
                         </div>
                         <div class="field">
-                            <label for="">Details</label>
+                            <label for="">Bio details</label>
                             <textarea name="details" id="details" cols="30" rows="10" value="{{ old('details') }}" required></textarea>
                             @error('details')
                                 <span class="error-msg">{{$message}}</span>


### PR DESCRIPTION
The following changes and fixes were made in this pr:
- Be able to click on a `domain` found in cso-directory page
- Remove `arrival` and `departure` from the lodge sidebar
- Put `Bio Details` instead of just `details` in expert registration
- `Name`, `sex`, `organization`, `Email`, `Phone Number`, `country of origin`, `your motivation to attend` added to event registration form
- Event card clickable
- Details field added to event creation
- `Start` and `end` date added to event creation
- Emails are sent to participants upon registration to events